### PR TITLE
Feature/support encode decode

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -27,7 +27,7 @@ std = [
 
 [dependencies]
 anyhow         = { version = "1.0.42", default-features = false }
-ethereum-types = { version = "0.12.0", default-features = false }
+ethereum-types = { version = "0.12.0", default-features = false, features = ["codec"] }
 hex            = { version = "0.4.3", default-features = false, features = ["alloc"] }
 serde          = { version = "1.0.126", features = ["derive"], optional = true }
 serde_json     = { version = "1.0.64", optional = true }

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -15,6 +15,8 @@ version = "14.1.0"
 [features]
 default = ["std"]
 
+codec = ["ethereum-types/codec"]
+
 std = [
 	"anyhow/std",
 	"hex/std",
@@ -27,7 +29,7 @@ std = [
 
 [dependencies]
 anyhow         = { version = "1.0.42", default-features = false }
-ethereum-types = { version = "0.12.0", default-features = false, features = ["codec"] }
+ethereum-types = { version = "0.11.0", default-features = false, features = ["codec"] }
 hex            = { version = "0.4.3", default-features = false, features = ["alloc"] }
 serde          = { version = "1.0.126", features = ["derive"], optional = true }
 serde_json     = { version = "1.0.64", optional = true }


### PR DESCRIPTION
Some changes for substrate v`3.0.0` compatiblity:

- Add `Encode` / `Decode` support to ethereum types.
- Downgrade to ethereum-types `0.11.0`, same as `sp-core-3.0.0` to avoid type mismatches.